### PR TITLE
Update package.json engine node to >=

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.2.2"
   },
   "engines": {
-    "node": "18"
+    "node": ">=18.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I currently can't yarn install garbo because of this:

```
% yarn install
yarn install v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error eslint-plugin-libram@0.3.1: The engine "node" is incompatible with this module. Expected version "18". Got "20.6.1"
error Found incompatible module.
```