### PR TITLE
Upgrade data-of-loathing to v3

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,7 +11,7 @@ const rules = {
 const plugin = {
   meta: {
     name: "eslint-plugin-libram",
-    version: "0.5.3",
+    version: "0.6.0",
   },
   configs: {
     get recommended() {

--- a/lib/loadData.ts
+++ b/lib/loadData.ts
@@ -1,127 +1,74 @@
-import { createClient } from "data-of-loathing";
+import {
+  createClient,
+  AscensionClass,
+  Effect,
+  Familiar,
+  Item,
+  Location,
+  Monster,
+  Meta,
+  Path,
+  Skill,
+} from "data-of-loathing";
 import fs from "fs/promises";
 import { join } from "path";
 
 const DATA_LOCATION = join(import.meta.dirname, "..", "data");
-const client = createClient();
 
-const exists = async (file: string) =>
-  fs
-    .access(file)
-    .then(() => true)
-    .catch(() => false);
+async function importData(requestedRevision?: number) {
+  const client = createClient();
+  await client.load();
 
-async function getRemoteRevision() {
-  return (
-    (
-      await client.query({
-        metaById: {
-          __args: {
-            id: 1,
-          },
-          lastRevision: true,
-        },
-      })
-    ).metaById?.lastRevision ?? 0
-  );
+  const em = client.query;
+
+  if (requestedRevision !== undefined) {
+    const localRevisionPath = `${DATA_LOCATION}/revision.json`;
+    try {
+      const localRevision = Number(await fs.readFile(localRevisionPath, "utf-8")) || 0;
+      if (localRevision >= requestedRevision) return;
+    } catch {
+      // no local revision file yet
+    }
+  }
+
+  const [classes, effects, familiars, items, locations, monsters, paths, skills, meta] =
+    await Promise.all([
+      em.findAll(AscensionClass, { orderBy: { id: "ASC" } }),
+      em.findAll(Effect, { orderBy: { id: "ASC" } }),
+      em.findAll(Familiar, { orderBy: { id: "ASC" } }),
+      em.findAll(Item, { orderBy: { id: "ASC" } }),
+      em.findAll(Location, { orderBy: { name: "ASC" } }),
+      em.findAll(Monster, { orderBy: { id: "ASC" } }),
+      em.findAll(Path, { orderBy: { id: "ASC" } }),
+      em.findAll(Skill, { orderBy: { id: "ASC" } }),
+      em.findOne(Meta, { id: 1 }),
+    ]);
+
+  const named = (records: Array<{ name: string }>) => records.map((r) => r.name);
+  const namedWithAmbiguous = (records: Array<{ id: number; name: string; ambiguous: boolean }>) =>
+    records.map((r) => (r.ambiguous ? `[${r.id}]${r.name}` : r.name));
+
+  await fs.mkdir(DATA_LOCATION, { recursive: true });
+
+  await Promise.all([
+    fs.writeFile(`${DATA_LOCATION}/classes.json`, JSON.stringify(named(classes))),
+    fs.writeFile(`${DATA_LOCATION}/effects.json`, JSON.stringify(namedWithAmbiguous(effects))),
+    fs.writeFile(`${DATA_LOCATION}/familiars.json`, JSON.stringify(named(familiars))),
+    fs.writeFile(`${DATA_LOCATION}/items.json`, JSON.stringify(namedWithAmbiguous(items))),
+    fs.writeFile(`${DATA_LOCATION}/locations.json`, JSON.stringify(named(locations))),
+    fs.writeFile(`${DATA_LOCATION}/monsters.json`, JSON.stringify(namedWithAmbiguous(monsters))),
+    fs.writeFile(`${DATA_LOCATION}/paths.json`, JSON.stringify(named(paths))),
+    fs.writeFile(`${DATA_LOCATION}/skills.json`, JSON.stringify(namedWithAmbiguous(skills))),
+    fs.writeFile(`${DATA_LOCATION}/revision.json`, JSON.stringify(meta?.lastRevision ?? 0)),
+  ]);
 }
 
 export async function verifyConstantsSinceRevision(requestedRevision?: number) {
-  if (!(await exists(DATA_LOCATION))) await fs.mkdir(DATA_LOCATION);
-
-  const localRevisionPath = `${DATA_LOCATION}/revision.json`;
-  const localRevision =
-    Number(
-      (await exists(localRevisionPath))
-        ? await fs.readFile(localRevisionPath, "utf-8")
-        : 0,
-    ) || 0;
-
-  // If our data is up to date, skip
-  if (requestedRevision && localRevision >= requestedRevision) return;
-
-  // If there is no newer data to be fetched anyway, skip
-  const remoteRevision = await getRemoteRevision();
-  if (localRevision >= remoteRevision) return;
-
-  const data = await client.query({
-    allClasses: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: false,
-      },
-    },
-    allEffects: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: true,
-      },
-    },
-    allFamiliars: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: false,
-      },
-    },
-    allItems: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: true,
-      },
-    },
-    allLocations: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: false,
-      },
-    },
-    allMonsters: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: true,
-      },
-    },
-    allPaths: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: false,
-      },
-    },
-    allSkills: {
-      nodes: {
-        id: true,
-        name: true,
-        ambiguous: true,
-      },
-    },
-  });
-
-  for (const e of Object.keys(data)) {
-    const entity = e as keyof typeof data;
-    const names =
-      data[entity]?.nodes
-        .filter((n) => n !== null)
-        .map((n) =>
-          "ambiguous" in n && n.ambiguous ? `[${n.id}]${n.name}` : n.name,
-        ) ?? [];
-
-    await fs.writeFile(
-      `${DATA_LOCATION}/${entity.slice(3).toLowerCase()}.json`,
-      JSON.stringify(names),
-    );
-  }
-
-  await fs.writeFile(localRevisionPath, JSON.stringify(remoteRevision));
+  await importData(requestedRevision);
 }
 
 if (import.meta.main) {
   console.log("Importing latest data...");
-  await verifyConstantsSinceRevision();
+  await importData();
+  console.log("Done.");
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "data/*.json"
   ],
   "dependencies": {
-    "data-of-loathing": "^2.6.2",
+    "data-of-loathing": "^3.2.2",
     "entities": "^7.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-libram",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Eslint rules for Libram",
   "keywords": [
     "eslint",

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,6 +400,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mikro-orm/core@npm:^7.0.14":
+  version: 7.0.15
+  resolution: "@mikro-orm/core@npm:7.0.15"
+  peerDependencies:
+    dataloader: 2.2.3
+  peerDependenciesMeta:
+    dataloader:
+      optional: true
+  checksum: 10c0/9dd237c086ef9603f336156557181dcaaa4a74f865b5795dce86f14655832d936186dee011fbb38b7086477e6f6cb13be25cd3bac9c2c62fb80cf306028f6207
+  languageName: node
+  linkType: hard
+
+"@mikro-orm/sql@npm:^7.0.14":
+  version: 7.0.15
+  resolution: "@mikro-orm/sql@npm:7.0.15"
+  dependencies:
+    kysely: "npm:0.28.17"
+  peerDependencies:
+    "@mikro-orm/core": 7.0.15
+  checksum: 10c0/1d7aacccd2da0d80e954367b427253f47dc4a23f4ff4fed14fc69f05a66c0ada97e29a0ed4aab58a4e073684f461eab8600fbee485a60264a73a576360ccac1e
+  languageName: node
+  linkType: hard
+
 "@npmcli/agent@npm:^2.0.0":
   version: 2.2.2
   resolution: "@npmcli/agent@npm:2.2.2"
@@ -580,6 +603,13 @@ __metadata:
   version: 4.53.5
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.53.5"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sqlite.org/sqlite-wasm@npm:~3.51.2-build9":
+  version: 3.51.2-build9
+  resolution: "@sqlite.org/sqlite-wasm@npm:3.51.2-build9"
+  checksum: 10c0/2b9c4d3df7b2cf84c1b311ac276c19692d8ccad4a4b34a1a739e1eb3b8938c6be4e64a98d51b7ea6e9ad5000a912d4ed0c25eec146f7eb468fa343b7ce491a08
   languageName: node
   linkType: hard
 
@@ -1202,10 +1232,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-of-loathing@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "data-of-loathing@npm:2.6.2"
-  checksum: 10c0/160be95e0886d797ddde79d25285cd3a09861097ac9131b7ceb5f2119648ba31d5d0ed1322e31a607140e9b610580095b95b4b6f72057790e12b1abd67ecbc17
+"data-of-loathing@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "data-of-loathing@npm:3.2.2"
+  dependencies:
+    "@mikro-orm/core": "npm:^7.0.14"
+    "@mikro-orm/sql": "npm:^7.0.14"
+    "@sqlite.org/sqlite-wasm": "npm:~3.51.2-build9"
+    env-paths: "npm:^4.0.0"
+    kysely: "npm:^0.28.17"
+  peerDependencies:
+    vite: ">=5.0.0"
+    vite-plugin-node-polyfills: ^0.26.0
+  peerDependenciesMeta:
+    vite:
+      optional: true
+    vite-plugin-node-polyfills:
+      optional: true
+  checksum: 10c0/c2238b96ef4be0e8c3384ca205ba80cb9b54e2c8e92d09c6d85f5fba0de316bfff642e899fbac874869ff32f50cac0b74bccbfeaec0d542f740f4c16384c832e
   languageName: node
   linkType: hard
 
@@ -1311,6 +1355,15 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "env-paths@npm:4.0.0"
+  dependencies:
+    is-safe-filename: "npm:^0.1.0"
+  checksum: 10c0/13ee7fa4047786ca28f1fbf2239606f8a53304bdf71bfc426e95f806e429060181205316f2c45b4ac560e81c854ded5a45fd9dc3105414c01d504b3469a1294b
   languageName: node
   linkType: hard
 
@@ -1470,7 +1523,7 @@ __metadata:
     "@types/node-fetch": "npm:^2.6.13"
     "@typescript-eslint/rule-tester": "npm:^8.50.0"
     "@vitest/coverage-v8": "npm:4.0.15"
-    data-of-loathing: "npm:^2.6.2"
+    data-of-loathing: "npm:^3.2.2"
     entities: "npm:^7.0.0"
     eslint: "npm:^9.39.2"
     jiti: "npm:^2.6.1"
@@ -2021,6 +2074,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-safe-filename@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "is-safe-filename@npm:0.1.1"
+  checksum: 10c0/45c35d2253b96348e2c26590e14feed51d1e6b72aaa567930ccb34e68c0eef00ebcf3b7e01b46bf45e578a27355cd8f5bc12f7d6d79a34d33dc93d4560c0f6b6
+  languageName: node
+  linkType: hard
+
 "isexe@npm:^2.0.0":
   version: 2.0.0
   resolution: "isexe@npm:2.0.0"
@@ -2148,6 +2208,13 @@ __metadata:
   dependencies:
     json-buffer: "npm:3.0.1"
   checksum: 10c0/aa52f3c5e18e16bb6324876bb8b59dd02acf782a4b789c7b2ae21107fab95fab3890ed448d4f8dba80ce05391eeac4bfabb4f02a20221342982f806fa2cf271e
+  languageName: node
+  linkType: hard
+
+"kysely@npm:0.28.17, kysely@npm:^0.28.17":
+  version: 0.28.17
+  resolution: "kysely@npm:0.28.17"
+  checksum: 10c0/70573292d8d60a1e29be9b432c1b25fe21d4806ecd5e9859b5ba8d2af799769878f4b3d91731ffe3e03744c7291476fe843640d31741f3637e20c3c49afea3c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrades `data-of-loathing` from `^2.6.2` to `^3.2.2`
- Rewrites `loadData.ts` to use the v3 MikroORM/SQLite client instead of the old GenQL/GraphQL client
- v3 downloads the SQLite database once to `~/.cache/data-of-loathing/` and caches it with ETags — no more revision-polling against a remote API before deciding whether to fetch

## How it works

v3 replaced the remote PostGraphile API with an embedded SQLite database. The `updateData` script now calls `client.load()` (which downloads/caches the DB) then queries via MikroORM's `EntityManager` — the same JSON files are written and distributed with the package as before.

The JSON-at-lint-time approach is unchanged: ESLint rule `create` functions are synchronous, so the async SQLite client is only usable in the build step. `verifyConstantsSinceRevision` is preserved as a public export.